### PR TITLE
Updated homepage banner

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,11 +4,13 @@ title: Weights and Measures Office
 description: An Isomer site of the Singapore Government
 image: /images/isomer-logo.svg
 permalink: /
-notification: From 1 July 2025, the Weights and Measures Office is transferred
-  to the Competition and Consumer Commission of Singapore.<br><br>Government
-  officials will NEVER ask you to transfer money or disclose bank log-in details
-  over a phone call. If in doubt, call the 24/7 ScamShield Helpline at 1799 or
-  visit https://www.scamshield.gov.sg.
+notification: The CPSA+ online portal will be undergoing scheduled maintenance
+  from 9 Jun 2026, 6:00 PM to 15 Jun 2026, 9.00 AM. Access to the system will
+  not be available during this period. For queries, please use the online
+  feedback form under ‘Contact Us’. <br><br> Government officials will NEVER ask
+  you to transfer money or disclose bank log-in details over a phone call. If in
+  doubt, call the 24/7 ScamShield Helpline at 1799 or visit <a
+  href="https://www.scamshield.gov.sg">https://www.scamshield.gov.sg</a>.
 sections:
   - hero:
       subtitle: <h3>Ensuring accuracy in daily transactions</h3><h3></h3>


### PR DESCRIPTION
The announcement banner was updated to inform visitors about the CPSA+ blackout period from 9 - 15 June 2026