### PR TITLE
Removal of Temporary WM Registers from Isomer Website

### DIFF
--- a/_about-us/faq/frequently-asked-questions-on-accuracy-label.md
+++ b/_about-us/faq/frequently-asked-questions-on-accuracy-label.md
@@ -71,7 +71,7 @@ prior to verification by Authorised Verifiers (AVs). The QR code label
 is to be affixed on the instrument by an AV.</p>
 <p>The QR code label serves different purpose for different stakeholders.</p>
 <p>For consumers, scanning the QR code of the instrument or searching for
-its 7-digit unique identification number in <a href="/files/Registry_of_Verified_Instruments___20260610_2.pdf" rel="noopener noreferrer nofollow" target="_blank">here</a> allows
+its 7-digit unique identification number in <a href="https://www.cpsaplus.gov.sg/Homepage/PublicRegistryInstrumentList" rel="noopener nofollow" target="_blank">CPSA+ public registry</a> allows
 them to access information about the instrument such as validity of its
 ACCURACY Label, date of last verification, as well as the business entity
 the instrument has been registered to in CPSA+.</p>

--- a/_about-us/faq/frequently-asked-questions-on-weights-and-measures.md
+++ b/_about-us/faq/frequently-asked-questions-on-weights-and-measures.md
@@ -51,7 +51,7 @@ consumers or traders.</p>
 <p>Your weighing or measuring instrument needs to be verified before it can
 be used for trade. Contact an Authorised Verifier (AV) to make arrangements
 to have your weighing or measuring instrument verified/stamped. A list
-of the AVs can be found at <a href="/files/Register_of_Authorized_Verifiers___20260610.pdf" rel="noopener noreferrer nofollow" target="_blank">List of Authorised Verifiers of Weighing and Measuring Instruments</a>.</p>
+of the AVs can be found at <a href="https://www.cpsaplus.gov.sg/Homepage/RegisterOfAuthorisedVerifier" rel="noopener nofollow" target="_blank">List of Authorised Verifiers of Weighing and Measuring Instruments</a>.</p>
 <p><strong>5. Why is there a need to register the pattern of weighing and measuring instruments for trade use?</strong>
 </p>
 <p>The pattern of a weighing and measuring instrument refers to the design

--- a/_businesses/suppliers-or-importers-of-weighing-and-measuring-instruments.md
+++ b/_businesses/suppliers-or-importers-of-weighing-and-measuring-instruments.md
@@ -42,7 +42,7 @@ any questions during this process, please contact us through our <a href="https:
 </p>
 </li>
 <li>
-<p><a href="/files/Registry_of_Registered_Supplier_and_Patterns_Granted_Pattern_Approval___20260610.pdf" rel="noopener noreferrer nofollow" target="_blank">Register of Weighing and Measuring Instruments Granted Pattern Approval</a>
+<p><a href="https://www.cpsaplus.gov.sg/Homepage/RegistryOfRegisteredSuppliersAndPatternApproval" rel="noopener nofollow" target="_blank">Register of Weighing and Measuring Instruments Granted Pattern Approval</a>
 </p>
 </li>
 </ul>

--- a/_businesses/users-of-weighing-and-measuring-instruments-for-trade.md
+++ b/_businesses/users-of-weighing-and-measuring-instruments-for-trade.md
@@ -13,7 +13,7 @@ use instruments pattern registered with the Weights and Measures Office
 (AV) and affixed with the ACCURACY Label before it can be used for trade
 purpose.</p>
 <p>You can find a list of WMO pattern registered weighing and measuring instruments
-in the <a href="/files/businesses/Registry_of_Registered_Supplier_and_Patterns_Granted_Pattern_Approval___20260610.pdf" rel="noopener noreferrer nofollow" target="_blank">Register of Weighing and Measuring Instruments Granted Pattern Approval</a>.</p>
+in the <a href="https://www.cpsaplus.gov.sg/Homepage/RegistryOfRegisteredSuppliersAndPatternApproval" rel="noopener nofollow" target="_blank">Register of Weighing and Measuring Instruments Granted Pattern Approval</a>.</p>
 <p><strong>Submit the instrument to an Authorized Verifier to verify that it is fit for trade use</strong>
 </p>
 <p>Under the Weights and Measures Act, it is an offence to use unregistered
@@ -21,13 +21,11 @@ i.e., not pattern registered, and/or unverified instruments for trade in
 Singapore.</p>
 <p>Businesses can contact one of the Authorized Verifiers (AVs) which are
 appointed by the WMO to carry out verification of these instruments. Their
-contact details can be found on our <a href="/files/Register_of_Authorized_Verifiers___20260610.pdf" rel="noopener noreferrer nofollow" target="_blank">Register of Authorized Verifiers</a>.</p>
+contact details can be found on our <a href="https://www.cpsaplus.gov.sg/Homepage/RegisterOfAuthorisedVerifier" rel="noopener nofollow" target="_blank">Register of Authorized Verifiers</a>.</p>
 <p>Instrument verification records are immediately approved when submitted
 by the AV through the WMO's application website (<a href="https://www.cpsaplus.gov.sg/HomePage/" rel="noopener noreferrer nofollow" target="_blank">CPSA+</a>). Members of public
 and businesses will be able to view the details of the instruments using
-the <a href="/files/Registry_of_Verified_Instruments___20260610_2.pdf" rel="noopener noreferrer nofollow" target="_blank">Register of Instruments</a>.</p>
-<p><em>(please note that CPSA+ online portal will be undergoing scheduled maintenance from 9 Jun 2026, 6:00 PM to 15 Jun 2026, 9.00 AM. Access to the system will not be available during this period)</em>
-</p>
+the <a href="https://www.cpsaplus.gov.sg/Homepage/PublicRegistryInstrumentList" rel="noopener nofollow" target="_blank">Register of Instruments</a>.</p>
 <p>Please refer to <strong>Appendix E</strong> of the Weights and Measures
 Information Booklet below for the process to get your instrument verified.</p>
 <p></p>
@@ -107,11 +105,11 @@ by weight, and Litre for goods measured by volume.</p>
 </p>
 </li>
 <li>
-<p><a href="/files/Register_of_Authorized_Verifiers___20260610.pdf" rel="noopener noreferrer nofollow" target="_blank">List of Authorised Verifiers of Weighing and Measuring Instrument</a>
+<p><a href="https://www.cpsaplus.gov.sg/Homepage/RegisterOfAuthorisedVerifier" rel="noopener nofollow" target="_blank">List of Authorised Verifiers of Weighing and Measuring Instruments</a>
 </p>
 </li>
 <li>
-<p><a href="/files/Registry_of_Verified_Instruments___20260610_2.pdf" rel="noopener noreferrer nofollow" target="_blank">List of Registered Weighing and Measuring Instruments</a>
+<p><a href="https://www.cpsaplus.gov.sg/Homepage/PublicRegistryInstrumentList" rel="noopener nofollow" target="_blank">List of Registered Weighing and Measuring Instruments</a>
 </p>
 </li>
 </ul>

--- a/_consumers/about-the-accuracy-label.md
+++ b/_consumers/about-the-accuracy-label.md
@@ -19,7 +19,7 @@ Effective 30 November 2021, weighing and measuring instruments used for trade wi
 
 The first 2 digits represent the year the instrument was registered in CPSA+. For example, instrument was registered by the AV in 2021, the unique identification number for the instrument would thus start with ‘21’ followed by its serialised number e.g., 21XXXXX.
 
-Consumers may either scan the QR code or search for the 7-digit unique identification number in the public registry here [](/files/Registry_of_Verified_Instruments___20260610_2.pdf), to access more information about the instrument such as validity of its ACCURACY Label, date of last verification, as well as the business owner/ user of the instrument.
+Consumers may either scan the QR code or search for the 7-digit unique identification number in the public registry [here](https://www.cpsaplus.gov.sg/Homepage/PublicRegistryInstrumentList), to access more information about the instrument such as validity of its ACCURACY Label, date of last verification, as well as the business owner/ user of the instrument.
 
 Scanning the QR code would also allow consumers to report on the instrument to the WMO. For example, if the instrument is found to have an expired ACCURACY Label, it is not reading zero even without any load placed on it, etc.
 

--- a/index.md
+++ b/index.md
@@ -4,12 +4,9 @@ title: Weights and Measures Office
 description: An Isomer site of the Singapore Government
 image: /images/isomer-logo.svg
 permalink: /
-notification: The CPSA+ online portal will be undergoing scheduled maintenance
-  from 9 Jun 2026, 6:00 PM to 15 Jun 2026, 9.00 AM. Access to the system will
-  not be available during this period. For queries, please use the online
-  feedback form under ‘Contact Us’. <br><br> Government officials will NEVER ask
-  you to transfer money or disclose bank log-in details over a phone call. If in
-  doubt, call the 24/7 ScamShield Helpline at 1799 or visit <a
+notification: Government officials will NEVER ask you to transfer money or
+  disclose bank log-in details over a phone call. If in doubt, call the 24/7
+  ScamShield Helpline at 1799 or visit <a
   href="https://www.scamshield.gov.sg">https://www.scamshield.gov.sg</a>.
 sections:
   - hero:


### PR DESCRIPTION
Remove:  
1) Removed 3 Temporary WM Registers post‑CPSA+ migration and restored the corresponding links in CPSA+
2) Removed notification on WM homepage that states that “The CPSA+ online portal will be undergoing scheduled maintenance......"